### PR TITLE
Changes required techweb on hazard nanites. Now they require illegal tech but cost is bigger.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -898,7 +898,7 @@
 	description = "Extremely advanced Nanite programs with the potential of being extremely dangerous."
 	prereq_ids = list("nanite_harmonic", "syndicate_basic")
 	design_ids = list("spreading_nanites","mindcontrol_nanites","mitosis_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
 	export_price = 20000
 
 ////////////////////////Alien technology////////////////////////


### PR DESCRIPTION
:cl: 
balance: Hazardous nanites are now loged beyond illegal tech instead of alien tech
/:cl:

[why]: Alien tech is too hard to acquire. You need or really lucky miners, or very, VERY specific gamemode which isn't too common too. While traitorous items aren't so easy to get too, they still don't require one specific rare gamemode at least, since traitors are more common-ish gamemode. Illegal tech is pretty hard to unlock, and price on hazard is now higher, so I think people won't unlock it earlier than it needs to.

Also, sorry, I'm not a coder, and it's first time of me using github PR's. Just I want to fix that issue.
